### PR TITLE
Fix monitor.matrix when input has zero variance

### DIFF
--- a/R/monitoring.R
+++ b/R/monitoring.R
@@ -354,7 +354,7 @@ monitor.matrix <- function(obj, X, y, verbose=TRUE){
     }
     boundary <- obj$border((obj$histsize+1):nrow(X))
     obj$statistic <- max(abs(obj$process))
-    if(!foundBreak & any(abs(obj$process) > boundary))
+    if(!foundBreak & all(is.finite(obj$process)) & any(abs(obj$process) > boundary))
     {
       foundBreak <- TRUE
       obj$breakpoint <- min(which(abs(obj$process) > boundary)) + obj$histsize

--- a/R/monitoring.R
+++ b/R/monitoring.R
@@ -370,7 +370,7 @@ monitor.matrix <- function(obj, X, y, verbose=TRUE){
                            obj$computeEmpProc(newestims$coef, newestims$Qr12,k))
       stat <- obj$computeStat(obj$process)
       obj$statistic <- c(obj$statistic, stat)
-      if(!foundBreak & (stat > obj$border(k))){
+      if(!foundBreak & is.finite(stat) & (stat > obj$border(k))){
         foundBreak <- TRUE
         obj$breakpoint <- k
         if(verbose) cat("Break detected at observation #", k, "\n")


### PR DESCRIPTION
In that case the result is NaN and you get the error:
```
Error in if (!foundBreak & any(abs(obj$process) > boundary)) { : 
  missing value where TRUE/FALSE needed
```
This assumes that if there is no variance, there is also no break.