### PR TITLE
Fix monitoring using an h value of 1

### DIFF
--- a/R/efp.R
+++ b/R/efp.R
@@ -343,7 +343,7 @@ efp.formula <- function(formula, data = list(),
   
   
   if(!is.ts(process))
-    process <- ts(process, start = 0, frequency = (NROW(process)-1))
+    process <- ts(process, start = 0, frequency = max(NROW(process)-1, 1))
   
   retval$process <- process
   
@@ -608,7 +608,7 @@ efp.matrix <- function(X,y,
   
   
   if(!is.ts(process))
-    process <- ts(process, start = 0, frequency = (NROW(process)-1))
+    process <- ts(process, start = 0, frequency = max(NROW(process)-1, 1))
   
   retval$process <- process
   


### PR DESCRIPTION
That always results in the process being a single value, and normally that is not a valid timeseries unless you set the frequency to at least 1.

This is required to fix bfastmonitor when h is set to 1.