### PR TITLE
Fix #35 (solaris build error)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Changes in Version 1.5-3-1.0.1
+
+  o Fix for build failures on Solaris and other architectures.
+
 Changes in Version 1.5-3-1.0.0
 
   o Initial release of the C++-optimised version of strucchange, strucchangeRcpp.

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,15 +2,15 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 .sc_cpp_rssi <- function(y, X, n, i, intercept_only, tol, rcond_min) {
-    .Call('_strucchange_sc_cpp_rssi', PACKAGE = 'strucchangeRcpp', y, X, n, i, intercept_only, tol, rcond_min)
+    .Call('_strucchangeRcpp_sc_cpp_rssi', PACKAGE = 'strucchangeRcpp', y, X, n, i, intercept_only, tol, rcond_min)
 }
 
 .sc_cpp_rss <- function(rss_triang, i, j) {
-    .Call('_strucchange_sc_cpp_rss', PACKAGE = 'strucchangeRcpp', rss_triang, i, j)
+    .Call('_strucchangeRcpp_sc_cpp_rss', PACKAGE = 'strucchangeRcpp', rss_triang, i, j)
 }
 
 .sc_cpp_extend_rss_table <- function(rss_table, rss_triang, n, h, breaks) {
-    .Call('_strucchange_sc_cpp_extend_rss_table', PACKAGE = 'strucchangeRcpp', rss_table, rss_triang, n, h, breaks)
+    .Call('_strucchangeRcpp_sc_cpp_extend_rss_table', PACKAGE = 'strucchangeRcpp', rss_table, rss_triang, n, h, breaks)
 }
 
 #' ..
@@ -20,7 +20,7 @@
 #' @param 
 #' @return 
 .sc_cpp_construct_rss_table <- function(y, X, n, h, breaks, intercept_only, tol, rcond_min) {
-    .Call('_strucchange_sc_cpp_construct_rss_table', PACKAGE = 'strucchangeRcpp', y, X, n, h, breaks, intercept_only, tol, rcond_min)
+    .Call('_strucchangeRcpp_sc_cpp_construct_rss_table', PACKAGE = 'strucchangeRcpp', y, X, n, h, breaks, intercept_only, tol, rcond_min)
 }
 
 #' Computes the empirical fluctuation process according to moving OLS estimates (type ME) 
@@ -30,7 +30,7 @@
 #' @param h bandwith of the process
 #' @return square root of X
 .sc_cpp_efp_process_me <- function(X, y, rescale, h) {
-    .Call('_strucchange_sc_cpp_efp_process_me', PACKAGE = 'strucchangeRcpp', X, y, rescale, h)
+    .Call('_strucchangeRcpp_sc_cpp_efp_process_me', PACKAGE = 'strucchangeRcpp', X, y, rescale, h)
 }
 
 #' Computes the empirical fluctuation process according to recursive OLS estimates (type RE) 
@@ -40,7 +40,7 @@
 #' @param h bandwith of the process
 #' @return square root of X
 .sc_cpp_efp_process_re <- function(X, y, rescale) {
-    .Call('_strucchange_sc_cpp_efp_process_re', PACKAGE = 'strucchangeRcpp', X, y, rescale)
+    .Call('_strucchangeRcpp_sc_cpp_efp_process_re', PACKAGE = 'strucchangeRcpp', X, y, rescale)
 }
 
 #' Compute F statistics for a data window
@@ -51,7 +51,7 @@
 #' @param rcond_min minimum reciprocal conditioning number to use armadillo::solve
 #' @return list with elements stats and sume2 where stats is a vector with F statistics and sume2 is the sum of squared residuals of the model using all data
 .sc_cpp_fstats <- function(X, y, istart, iend, rcond_min) {
-    .Call('_strucchange_sc_cpp_fstats', PACKAGE = 'strucchangeRcpp', X, y, istart, iend, rcond_min)
+    .Call('_strucchangeRcpp_sc_cpp_fstats', PACKAGE = 'strucchangeRcpp', X, y, istart, iend, rcond_min)
 }
 
 #' Computation of recursive residuals in C++
@@ -73,20 +73,20 @@ NULL
 #' @return vector containing the recursive residuals 
 #' @seealso \code{\link{recresid}} and \code{\link{recresid.default}}
 .sc_cpp_recresid <- function(X, y, start, end, tol, rcond_min) {
-    .Call('_strucchange_sc_cpp_recresid', PACKAGE = 'strucchangeRcpp', X, y, start, end, tol, rcond_min)
+    .Call('_strucchangeRcpp_sc_cpp_recresid', PACKAGE = 'strucchangeRcpp', X, y, start, end, tol, rcond_min)
 }
 
 #' Computes the square root of a symetric positive definite matrix
 #' @param X symetric positive definite matrix
 #' @return square root of X
 .sc_cpp_rootmatrix <- function(X) {
-    .Call('_strucchange_sc_cpp_rootmatrix', PACKAGE = 'strucchangeRcpp', X)
+    .Call('_strucchangeRcpp_sc_cpp_rootmatrix', PACKAGE = 'strucchangeRcpp', X)
 }
 
 #' Computes the square root of the Gramian matrix t(X) %*% X
 #' @param X a matrix
 #' @return square root of t(X) %*% X
 .sc_cpp_rootmatrix_cross <- function(X) {
-    .Call('_strucchange_sc_cpp_rootmatrix_cross', PACKAGE = 'strucchangeRcpp', X)
+    .Call('_strucchangeRcpp_sc_cpp_rootmatrix_cross', PACKAGE = 'strucchangeRcpp', X)
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -8,7 +8,7 @@ using namespace Rcpp;
 
 // sc_cpp_rssi
 arma::vec sc_cpp_rssi(const arma::vec& y, const arma::mat& X, int n, int i, const bool intercept_only, const double& tol, const double& rcond_min);
-RcppExport SEXP _strucchange_sc_cpp_rssi(SEXP ySEXP, SEXP XSEXP, SEXP nSEXP, SEXP iSEXP, SEXP intercept_onlySEXP, SEXP tolSEXP, SEXP rcond_minSEXP) {
+RcppExport SEXP _strucchangeRcpp_sc_cpp_rssi(SEXP ySEXP, SEXP XSEXP, SEXP nSEXP, SEXP iSEXP, SEXP intercept_onlySEXP, SEXP tolSEXP, SEXP rcond_minSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -25,7 +25,7 @@ END_RCPP
 }
 // sc_cpp_rss
 double sc_cpp_rss(const arma::mat& rss_triang, const int i, const int j);
-RcppExport SEXP _strucchange_sc_cpp_rss(SEXP rss_triangSEXP, SEXP iSEXP, SEXP jSEXP) {
+RcppExport SEXP _strucchangeRcpp_sc_cpp_rss(SEXP rss_triangSEXP, SEXP iSEXP, SEXP jSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -38,7 +38,7 @@ END_RCPP
 }
 // sc_cpp_extend_rss_table
 arma::mat sc_cpp_extend_rss_table(arma::mat& rss_table, const arma::mat& rss_triang, int n, int h, int breaks);
-RcppExport SEXP _strucchange_sc_cpp_extend_rss_table(SEXP rss_tableSEXP, SEXP rss_triangSEXP, SEXP nSEXP, SEXP hSEXP, SEXP breaksSEXP) {
+RcppExport SEXP _strucchangeRcpp_sc_cpp_extend_rss_table(SEXP rss_tableSEXP, SEXP rss_triangSEXP, SEXP nSEXP, SEXP hSEXP, SEXP breaksSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -53,7 +53,7 @@ END_RCPP
 }
 // sc_cpp_construct_rss_table
 List sc_cpp_construct_rss_table(const arma::vec& y, const arma::mat& X, int n, int h, int breaks, const bool intercept_only, const double& tol, const double& rcond_min);
-RcppExport SEXP _strucchange_sc_cpp_construct_rss_table(SEXP ySEXP, SEXP XSEXP, SEXP nSEXP, SEXP hSEXP, SEXP breaksSEXP, SEXP intercept_onlySEXP, SEXP tolSEXP, SEXP rcond_minSEXP) {
+RcppExport SEXP _strucchangeRcpp_sc_cpp_construct_rss_table(SEXP ySEXP, SEXP XSEXP, SEXP nSEXP, SEXP hSEXP, SEXP breaksSEXP, SEXP intercept_onlySEXP, SEXP tolSEXP, SEXP rcond_minSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -71,7 +71,7 @@ END_RCPP
 }
 // sc_cpp_efp_process_me
 List sc_cpp_efp_process_me(const arma::mat& X, const arma::vec& y, bool rescale, double h);
-RcppExport SEXP _strucchange_sc_cpp_efp_process_me(SEXP XSEXP, SEXP ySEXP, SEXP rescaleSEXP, SEXP hSEXP) {
+RcppExport SEXP _strucchangeRcpp_sc_cpp_efp_process_me(SEXP XSEXP, SEXP ySEXP, SEXP rescaleSEXP, SEXP hSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -85,7 +85,7 @@ END_RCPP
 }
 // sc_cpp_efp_process_re
 List sc_cpp_efp_process_re(const arma::mat& X, const arma::vec& y, bool rescale);
-RcppExport SEXP _strucchange_sc_cpp_efp_process_re(SEXP XSEXP, SEXP ySEXP, SEXP rescaleSEXP) {
+RcppExport SEXP _strucchangeRcpp_sc_cpp_efp_process_re(SEXP XSEXP, SEXP ySEXP, SEXP rescaleSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -98,7 +98,7 @@ END_RCPP
 }
 // sc_cpp_fstats
 List sc_cpp_fstats(const arma::mat& X, const arma::vec& y, int istart, int iend, double& rcond_min);
-RcppExport SEXP _strucchange_sc_cpp_fstats(SEXP XSEXP, SEXP ySEXP, SEXP istartSEXP, SEXP iendSEXP, SEXP rcond_minSEXP) {
+RcppExport SEXP _strucchangeRcpp_sc_cpp_fstats(SEXP XSEXP, SEXP ySEXP, SEXP istartSEXP, SEXP iendSEXP, SEXP rcond_minSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -113,7 +113,7 @@ END_RCPP
 }
 // sc_cpp_recresid
 NumericVector sc_cpp_recresid(const arma::mat& X, const arma::vec& y, unsigned int start, unsigned int end, const double& tol, const double& rcond_min);
-RcppExport SEXP _strucchange_sc_cpp_recresid(SEXP XSEXP, SEXP ySEXP, SEXP startSEXP, SEXP endSEXP, SEXP tolSEXP, SEXP rcond_minSEXP) {
+RcppExport SEXP _strucchangeRcpp_sc_cpp_recresid(SEXP XSEXP, SEXP ySEXP, SEXP startSEXP, SEXP endSEXP, SEXP tolSEXP, SEXP rcond_minSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -129,7 +129,7 @@ END_RCPP
 }
 // sc_cpp_rootmatrix
 arma::mat sc_cpp_rootmatrix(const arma::mat& X);
-RcppExport SEXP _strucchange_sc_cpp_rootmatrix(SEXP XSEXP) {
+RcppExport SEXP _strucchangeRcpp_sc_cpp_rootmatrix(SEXP XSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -140,7 +140,7 @@ END_RCPP
 }
 // sc_cpp_rootmatrix_cross
 arma::mat sc_cpp_rootmatrix_cross(const arma::mat& X);
-RcppExport SEXP _strucchange_sc_cpp_rootmatrix_cross(SEXP XSEXP) {
+RcppExport SEXP _strucchangeRcpp_sc_cpp_rootmatrix_cross(SEXP XSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -151,20 +151,20 @@ END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
-    {"_strucchange_sc_cpp_rssi", (DL_FUNC) &_strucchange_sc_cpp_rssi, 7},
-    {"_strucchange_sc_cpp_rss", (DL_FUNC) &_strucchange_sc_cpp_rss, 3},
-    {"_strucchange_sc_cpp_extend_rss_table", (DL_FUNC) &_strucchange_sc_cpp_extend_rss_table, 5},
-    {"_strucchange_sc_cpp_construct_rss_table", (DL_FUNC) &_strucchange_sc_cpp_construct_rss_table, 8},
-    {"_strucchange_sc_cpp_efp_process_me", (DL_FUNC) &_strucchange_sc_cpp_efp_process_me, 4},
-    {"_strucchange_sc_cpp_efp_process_re", (DL_FUNC) &_strucchange_sc_cpp_efp_process_re, 3},
-    {"_strucchange_sc_cpp_fstats", (DL_FUNC) &_strucchange_sc_cpp_fstats, 5},
-    {"_strucchange_sc_cpp_recresid", (DL_FUNC) &_strucchange_sc_cpp_recresid, 6},
-    {"_strucchange_sc_cpp_rootmatrix", (DL_FUNC) &_strucchange_sc_cpp_rootmatrix, 1},
-    {"_strucchange_sc_cpp_rootmatrix_cross", (DL_FUNC) &_strucchange_sc_cpp_rootmatrix_cross, 1},
+    {"_strucchangeRcpp_sc_cpp_rssi", (DL_FUNC) &_strucchangeRcpp_sc_cpp_rssi, 7},
+    {"_strucchangeRcpp_sc_cpp_rss", (DL_FUNC) &_strucchangeRcpp_sc_cpp_rss, 3},
+    {"_strucchangeRcpp_sc_cpp_extend_rss_table", (DL_FUNC) &_strucchangeRcpp_sc_cpp_extend_rss_table, 5},
+    {"_strucchangeRcpp_sc_cpp_construct_rss_table", (DL_FUNC) &_strucchangeRcpp_sc_cpp_construct_rss_table, 8},
+    {"_strucchangeRcpp_sc_cpp_efp_process_me", (DL_FUNC) &_strucchangeRcpp_sc_cpp_efp_process_me, 4},
+    {"_strucchangeRcpp_sc_cpp_efp_process_re", (DL_FUNC) &_strucchangeRcpp_sc_cpp_efp_process_re, 3},
+    {"_strucchangeRcpp_sc_cpp_fstats", (DL_FUNC) &_strucchangeRcpp_sc_cpp_fstats, 5},
+    {"_strucchangeRcpp_sc_cpp_recresid", (DL_FUNC) &_strucchangeRcpp_sc_cpp_recresid, 6},
+    {"_strucchangeRcpp_sc_cpp_rootmatrix", (DL_FUNC) &_strucchangeRcpp_sc_cpp_rootmatrix, 1},
+    {"_strucchangeRcpp_sc_cpp_rootmatrix_cross", (DL_FUNC) &_strucchangeRcpp_sc_cpp_rootmatrix_cross, 1},
     {NULL, NULL, 0}
 };
 
-RcppExport void R_init_strucchange(DllInfo *dll) {
+RcppExport void R_init_strucchangeRcpp(DllInfo *dll) {
     R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
     R_useDynamicSymbols(dll, FALSE);
 }

--- a/src/breakpoints.cpp
+++ b/src/breakpoints.cpp
@@ -53,7 +53,7 @@ double sc_cpp_rss(const arma::mat& rss_triang, const int i, const int j) {
 arma::mat sc_cpp_extend_rss_table(arma::mat& rss_table, const arma::mat& rss_triang, int n, int h, int breaks) {
   // extend table
   int n_rows = rss_table.n_rows;
-  if (2*breaks <= rss_table.n_cols) {
+  if (2*breaks <=  int(rss_table.n_cols)) {
     return rss_table;
   }
   arma::mat na(n_rows,2); 

--- a/src/efp.cpp
+++ b/src/efp.cpp
@@ -25,12 +25,12 @@ List sc_cpp_efp_process_me(const arma::mat& X,const arma::vec& y, bool rescale, 
   double sigma = sqrt(arma::as_scalar(arma::trans(resid_hat)*resid_hat/(n-k)));
   int nh = floor(n*h);
   arma::mat process(k, n-nh+1, arma::fill::zeros);
-  arma::mat Q12 = sc_cpp_rootmatrix_cross(X)/sqrt(n);
+  arma::mat Q12 = sc_cpp_rootmatrix_cross(X)/std::sqrt(n);
 
   for(int i=0; i <= n-nh; ++i) {
     arma::mat Xsub = X.submat(i, 0, i+nh-1, X.n_cols - 1);
     if (rescale) {
-      arma::mat Qnh12 = sc_cpp_rootmatrix_cross(Xsub)/sqrt(nh);
+      arma::mat Qnh12 = sc_cpp_rootmatrix_cross(Xsub)/std::sqrt(nh);
       process.col(i) = Qnh12 * (arma::solve(Xsub, y.subvec(i,i+nh-1), arma::solve_opts::no_approx) - coef_hat);
     } 
     else {
@@ -38,7 +38,7 @@ List sc_cpp_efp_process_me(const arma::mat& X,const arma::vec& y, bool rescale, 
     }
     
   }
-  process = nh*trans(process)/(sqrt(n)*sigma); 
+  process = nh*trans(process)/(std::sqrt(n)*sigma); 
   
   return List::create(Named("process") = process,
                       Named("Q12")     = Q12);
@@ -63,11 +63,11 @@ List sc_cpp_efp_process_re(const arma::mat& X,const arma::vec& y, bool rescale) 
   double sigma = sqrt(arma::as_scalar(arma::trans(resid_hat)*resid_hat/(n-k)));
 
   arma::mat process(k, n-k+2, arma::fill::zeros);
-  arma::mat Q12 = sc_cpp_rootmatrix_cross(X)/sqrt(n);
+  arma::mat Q12 = sc_cpp_rootmatrix_cross(X)/std::sqrt(n);
   for(int i=k; i <= n-1; ++i) {
     arma::mat Xsub = X.submat(0, 0, i-1, X.n_cols - 1);
     if (rescale) {
-      arma::mat Qi12 = sc_cpp_rootmatrix_cross(Xsub)/sqrt(i);
+      arma::mat Qi12 = sc_cpp_rootmatrix_cross(Xsub)/std::sqrt(i);
       process.col(i-k+1) = Qi12 * (arma::solve(Xsub, y.subvec(0,i-1), arma::solve_opts::no_approx) - coef_hat);
     } 
     else {
@@ -76,7 +76,7 @@ List sc_cpp_efp_process_re(const arma::mat& X,const arma::vec& y, bool rescale) 
   }
   arma::vec v= arma::linspace<arma::vec>( k-1, n, n-(k-1)+1);
   arma::mat tp = trans(process);
-  tp = (tp.each_col() % v)/(sqrt(n)*sigma);
+  tp = (tp.each_col() % v)/(std::sqrt(n)*sigma);
   return List::create(Named("process") = tp,
                       Named("Q12")     = Q12);
 }

--- a/src/fstats.cpp
+++ b/src/fstats.cpp
@@ -44,10 +44,7 @@ List sc_cpp_fstats(const arma::mat& X,const arma::vec& y,int istart, int iend, d
    // rss_all = arma::as_scalar(arma::sum(arma::square(y - X*coef)));
  }
   
-  uint32_t count_X1_arma = 0;
-  uint32_t count_X1_R = 0;
   uint32_t count_X2_arma = 0;
-  uint32_t count_X2_R = 0;
   
   for (int i = istart - 1; i <= iend - 1; ++i) {
     arma::mat X1 = X.submat(0,0,i,k-1);


### PR DESCRIPTION
I could reproduce the bug on https://builder.r-hub.io. See logs of R-hub builds for [master](https://builder.r-hub.io/status/original/strucchangeRcpp_1.5-3-1.0.0.9000.tar.gz-ff8a73e3de4dd911ce241f07b1210733) and [solaris_build](https://builder.r-hub.io/status/original/strucchangeRcpp_1.5-3-1.0.0.9000.tar.gz-23b16c1f0c018486741072b29c0f360e) branches.
This pull request also includes fixing some -Wunused_variable and Wsign-compare compiler warnings.
