### PR TITLE
Switch from deprecated arma::is_finite to member .is_finite

### DIFF
--- a/src/recresid.cpp
+++ b/src/recresid.cpp
@@ -80,7 +80,7 @@ arma::vec sc_cpp_recresid_arma(const arma::mat& X, const arma::vec& y,  unsigned
         if (1/arma::cond(cur_X) >= rcond_min) {
           arma::solve(cur_coef_full, cur_X, cur_y, arma::solve_opts::no_approx);
           arma::inv_sympd(X1, trans(cur_X) * cur_X);
-          bool nona = arma::is_finite( cur_coef) && arma::is_finite( cur_coef_full );
+          bool nona = cur_coef.is_finite() && cur_coef_full.is_finite();
           if(nona && approx_equal(cur_coef_full,cur_coef, "absdiff", tol)) {
             check = false;
           } 
@@ -90,7 +90,7 @@ arma::vec sc_cpp_recresid_arma(const arma::mat& X, const arma::vec& y,  unsigned
           NumericMatrix qrinv = fXinv0(fitted);
           X1 =  as<arma::mat>(qrinv);
           arma::colvec coef1 = as<arma::colvec>(fitted["coefficients"]);
-          bool nona = arma::is_finite( coef1 ) && arma::is_finite( cur_coef_full );
+          bool nona = coef1.is_finite() && cur_coef_full.is_finite();
           if(nona && approx_equal(coef1,cur_coef, "absdiff", tol)) {
             check = false;
           } 


### PR DESCRIPTION
Armadillo 15.0.* now makes C++14 the minimum compilation standard, which also means I can no-longer add the suppression of deprecation warnings (which used a macro before and now use a C++14 or later attribute). For most packages, adapting to it can be very simple, and yours is one of them -- in fact it is just a four statements on two lines. In the patch below we simply update this as now required by Armadillo 15.0.x.  

Please see issues [#475](https://github.com/RcppCore/RcppArmadillo/issues/475) and below at the RcppArmadillo GitHub repo for context, and notably [#491](https://github.com/RcppCore/RcppArmadillo/issues/491) for this second wave of PRs and patches (following one for moving away from C++11, something your package does not need). It would be terrific if you could make an upload to CRAN 'soon' to remove the deprecation warning. Please do not hesitate to reach out if I can assist in any way or clarify matters.